### PR TITLE
記事部分の見出しをCSS調整する

### DIFF
--- a/assets/css/module/markdown.styl
+++ b/assets/css/module/markdown.styl
@@ -2,8 +2,8 @@
   word-wrap break-word
 
   h1, h2, h3, h4, h5, h6
-    margin-top 2.8em
-    margin-bottom 0.75em
+    margin-top 2.9em
+    margin-bottom 1.0em
     line-height 1.4
 
   h4, h5, h6
@@ -11,10 +11,10 @@
 
   h2
     padding 0.8em
-    border 1px solid #888
+    border 1px solid #666
     border-radius 3px
-    background-color #f5f5f5
-    font-size 1.75em
+    background-color #fff
+    font-size 1.8em
 
   h3
     font-size 1.65em


### PR DESCRIPTION
### やったこと
- [x] `h2`の背景色を白くする。
- [x] 見出しの上下マージンを更に広くする。
