### PR TITLE
CircleCI にて Hugo インストールが落ちる問題を修正する

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,9 @@ machine:
 
 dependencies:
   pre:
-    - go get -v github.com/spf13/hugo
+    # - go get -v github.com/spf13/hugo
+    - curl -LO https://github.com/spf13/hugo/releases/download/v0.15/hugo_0.15_amd64.deb
+    - sudo dpkg -i hugo_0.15_amd64.deb
     - git config --global user.name "Circle CI"
     - git config --global user.email "circleci@example.com"
 


### PR DESCRIPTION
https://circleci.com/gh/namikingsoft/namikingsoft.github.io/123

go のバージョンが古いから？
取り急ぎ、deb から直接インストールする方法に切り替える。